### PR TITLE
Pin dropbox version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apk add --no-cache --virtual .build \
         azure-storage \
         b2 \
         boto \
-        dropbox \
+        dropbox==6.9.0 \
         gdata \
         lockfile \
         mediafire \


### PR DESCRIPTION
Pin dropbox to the latest [supported version](https://bazaar.launchpad.net/~duplicity-team/duplicity/0.7-series/view/head:/requirements.txt). `duplicity` is not compatible with higher versions.