### PR TITLE
[FIX] Pin 'PyNaCl' version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN apk add --no-cache --virtual .build \
         pyrax \
         python-keystoneclient \
         python-swiftclient \
+        PyNaCl==1.2.1 \
         requests \
         requests-oauthlib \
         urllib3 \


### PR DESCRIPTION
Fixes the installation of `PyNaCl`, which is failing with the following error:

> Could not find a version that satisfies the requirement cffi>=1.4.1 (from versions: )
> No matching distribution found for cffi>=1.4.1

Related Alpine bug report: https://bugs.alpinelinux.org/issues/9475