### PR TITLE
Feature/wait for mail availability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apk add --no-cache --virtual .build \
         linux-headers \
         openssl-dev \
         python-dev \
+        busybox-extras \
     && pip install --no-cache-dir --no-use-pep517 \
         azure-storage \
         b2 \

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ services:
             OPTIONS: --s3-european-buckets --s3-use-new-style
             PASSPHRASE: example backup encryption secret
 ```
+### wait for availability of smtp
+
+When restart your mail stack during some backup steps, you may want to wait for it in front of sending the backup-status mail. This can be achieved by: (ensure to replace <MY_SMTPP_HOST>)
+```yaml
+  environment:
+    JOB_500_WHAT:
+      while true; do sleep 1 | telnet <MY_SMTP_HOST> 25 && break; done
+```
+Since the JOB_500 is executed after the backup JOB_200, the sleep loop ensures a valid connection to the smtp host in front of deploying the mail.
 
 ### Amazon S3 (`*-s3`)
 


### PR DESCRIPTION
I use this backup image as a generic way to stop the containers, backup the volumes and start them afterwards. This usage integrates very powerful with the docker named volume mechanism. Nevertheless, this usage has one penalty:

When i stop, backup and start my mail-stack, the service receiving the status mail is not yet available, when the backup job tries to send the status mail. One easy solution is add a wait-loop for the smtp availability as a post-backup step.

Therefor i use telnet, which i install in this image. Also i added some documentation how to achieve this smtp availability using a code-snipped example.