### PR TITLE
Install pexpect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN apk add --no-cache --virtual .build \
         jottalib \
         mediafire \
         paramiko \
+        pexpect \
         pydrive \
         python-swiftclient \
         requests_oauthlib \


### PR DESCRIPTION
pexpect should be installed so `pexpect+sftp://user@host//folder` is supported.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=866062