### PR TITLE
Force text mode in subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ By default, SRC is set to /mnt/backup/src/ inside the container. Simply mount an
 external directory as a volume to /mnt/backup/src/. If you wish to include multiple
 directories, mount them as subdirectories of /mnt/backup/src/, like...
 
-```
+```yaml
 volumes:
-            - /path/to/data/to/backup1:/mnt/backup/src/foldername1:ro
-            - /path/to/data/to/backup2:/mnt/backup/src/foldername2:ro
+  - /path/to/data/to/backup1:/mnt/backup/src/foldername1:ro
+  - /path/to/data/to/backup2:/mnt/backup/src/foldername2:ro
 ```
 
 ### `TZ`

--- a/bin/jobrunner
+++ b/bin/jobrunner
@@ -56,7 +56,7 @@ for njob, command in sorted(to_run.items()):
     start = datetime.now()
     logging.info("Running job %d: `%s`", njob, expanded_command)
     try:
-        result = check_output(expanded_command, stderr=STDOUT, shell=True,)
+        result = check_output(expanded_command, stderr=STDOUT, shell=True, text=True)
         success = True
     except CalledProcessError as error:
         failed = True


### PR DESCRIPTION


Without this patch, we were obtaining this error due to the change to Python 3.8:

```
INFO:jobrunner:2020-05-06 17:51:35.962457 UTC - Running daily jobs
INFO:jobrunner:Running job 200: `psql -0Atd postgres -c "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres'" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file "/mnt/backup/src/DB.sql"`
Traceback (most recent call last):
  File "/etc/periodic/daily/jobrunner", line 77, in <module>
    logging.log(logging.INFO if success else logging.ERROR, "\n".join(log))
TypeError: sequence item 7: expected str instance, bytes found
 ```

