### PR TITLE
Update duplicity packages and postgres libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN apk add --no-cache --virtual .build \
         python-swiftclient \
         requests_oauthlib \
         # Duplicity from source code
-        https://gitlab.com/duplicity/duplicity/-/archive/rel.0.8.14/duplicity-rel.0.8.14.tar.bz2 \
+        https://gitlab.com/duplicity/duplicity/-/archive/rel.0.8.16/duplicity-rel.0.8.16.tar.bz2 \
     && apk del .build
 
 COPY bin/* /usr/local/bin/
@@ -104,7 +104,133 @@ ENV JOB_500_WHAT='dup full $SRC $DST' \
 
 
 FROM latest AS postgres
-RUN apk add --no-cache postgresql
+
+# HACK: Compile postgres from source (like in https://github.com/docker-library/postgres/blob/04bf35f0c4a3f7ac41591f9b28e2de1fecb7fef4/13/alpine/Dockerfile)
+# while package is not available in alpine repos
+# TODO: Switch back to `apk add postgres` when it becomes available
+
+ENV LANG en_US.utf8
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PG_MAJOR 13
+ENV PG_VERSION 13.0
+ENV PG_SHA256 80e750be8d436b54197636a02636f8fd3263ba6779bf865b04832495ea592296
+
+RUN set -eux; \
+	\
+	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
+	echo "$PG_SHA256 *postgresql.tar.bz2" | sha256sum -c -; \
+	mkdir -p /usr/src/postgresql; \
+	tar \
+		--extract \
+		--file postgresql.tar.bz2 \
+		--directory /usr/src/postgresql \
+		--strip-components 1 \
+	; \
+	rm postgresql.tar.bz2; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		bison \
+		coreutils \
+		dpkg-dev dpkg \
+		flex \
+		gcc \
+#		krb5-dev \
+		libc-dev \
+		libedit-dev \
+		libxml2-dev \
+		libxslt-dev \
+		linux-headers \
+		llvm10-dev clang g++ \
+		make \
+#		openldap-dev \
+		openssl-dev \
+# configure: error: prove not found
+		perl-utils \
+# configure: error: Perl module IPC::Run is required to run TAP tests
+		perl-ipc-run \
+#		perl-dev \
+#		python-dev \
+#		python3-dev \
+#		tcl-dev \
+		util-linux-dev \
+		zlib-dev \
+		icu-dev \
+	; \
+	\
+	cd /usr/src/postgresql; \
+# update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
+# see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
+	awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new; \
+	grep '/var/run/postgresql' src/include/pg_config_manual.h.new; \
+	mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h; \
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
+	./configure \
+		--build="$gnuArch" \
+# "/usr/src/postgresql/src/backend/access/common/tupconvert.c:105: undefined reference to `libintl_gettext'"
+#		--enable-nls \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+# skip debugging info -- we want tiny size instead
+#		--enable-debug \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		\
+# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
+#		--with-krb5 \
+#		--with-gssapi \
+#		--with-ldap \
+#		--with-tcl \
+#		--with-perl \
+#		--with-python \
+#		--with-pam \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+	; \
+	make -j "$(nproc)" world; \
+	make install-world; \
+	make -C contrib install; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-cache --virtual .postgresql-rundeps \
+		$runDeps \
+		bash \
+		su-exec \
+# tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
+# https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
+		tzdata \
+	; \
+	apk del --no-network .build-deps; \
+	cd /; \
+	rm -rf \
+		/usr/src/postgresql \
+		/usr/local/share/doc \
+		/usr/local/share/man \
+	; \
+	\
+	postgres --version
+
 ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
 ENV JOB_200_WHEN='daily weekly' \
     PGHOST=db


### PR DESCRIPTION
Postgresql client should update to latest version on build.
Current latest is version 12.4

This should fix incompatibility problems with Postgresql v13.

TT26463