### PR TITLE
Add dbs to exclude (+ fix prettier)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,9 @@ jobs:
       - uses: actions/setup-python@v1
       - name: Set PY
         run:
-          echo "::set-env name=PY::$(python -c 'import hashlib,
+          echo "PY=$(python -c 'import hashlib,
           sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+          >> $GITHUB_ENV
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.0
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV CRONTAB_15MIN='*/15 * * * *' \
     CRONTAB_DAILY='0 2 * * MON-SAT' \
     CRONTAB_WEEKLY='0 1 * * SUN' \
     CRONTAB_MONTHLY='0 5 1 * *' \
+    DBS_TO_EXCLUDE='$^' \
     DST='' \
     EMAIL_FROM='' \
     EMAIL_SUBJECT='Backup report: {hostname} - {periodicity} - {result}' \
@@ -231,7 +232,7 @@ RUN set -eux; \
 	\
 	postgres --version
 
-ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
+ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
 ENV JOB_200_WHEN='daily weekly' \
     PGHOST=db
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Where?](#where)
 - [Environment variables available](#environment-variables-available)
   - [`CRONTAB_{15MIN,HOURLY,DAILY,WEEKLY,MONTHLY}`](#crontab_15minhourlydailyweeklymonthly)
+  - [`DBS_TO_EXCLUDE`](#dbs_to_exclude)
   - [`DST`](#dst)
   - [`EMAIL_FROM`](#email_from)
   - [`EMAIL_SUBJECT`](#email_subject)
@@ -30,7 +31,6 @@
   - [`SMTP_TLS`](#smtp_tls)
   - [`SRC`](#src)
   - [`TZ`](#tz)
-  - [`DBS_TO_EXCLUDE`](#dbs_to_exclude)
 - [Set a custom hostname!](#set-a-custom-hostname)
 - [Pre and post scripts](#pre-and-post-scripts)
 - [Using Duplicity](#using-duplicity)
@@ -97,6 +97,21 @@ CRONTAB_HOURLY=0 * * * *
 CRONTAB_DAILY=0 2 * * MON-SAT
 CRONTAB_WEEKLY=0 1 * * SUN
 CRONTAB_MONTHLY=0 5 1 * *
+```
+
+### `DBS_TO_EXCLUDE`
+
+Define a Regular Expression to filter databases that shouldn't be included in the DB
+dump.
+
+You can use this to avoid getting permission errors when running a backup against a
+server where you don't control all the databases.
+
+For example, if you don't want to include the databases named `DB1` and `DB2` you can
+use:
+
+```bash
+DBS_TO_EXCLUDE="^(DB1|DB2)$"
 ```
 
 ### `DST`
@@ -199,21 +214,6 @@ match your local reality.
 
 This is achieved directly by bundling [the `tzdata` package][tzdata]. Refer to its docs
 for more info.
-
-### `DBS_TO_EXCLUDE`
-
-Define a Regular Expression to filter databases that shouldn't be included in the DB
-dump.
-
-You can use this to avoid getting permission errors when running a backup against a
-server where you don't control all the databases.
-
-For example, if you don't want to include the databases named `DB1` and `DB2` you can
-use:
-
-```bash
-DBS_TO_EXCLUDE="^(DB1|DB2)$"
-```
 
 ## Set a custom hostname!
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [`SMTP_TLS`](#smtp_tls)
   - [`SRC`](#src)
   - [`TZ`](#tz)
+  - [`DBS_TO_EXCLUDE`](#dbs_to_exclude)
 - [Set a custom hostname!](#set-a-custom-hostname)
 - [Pre and post scripts](#pre-and-post-scripts)
 - [Using Duplicity](#using-duplicity)
@@ -198,6 +199,21 @@ match your local reality.
 
 This is achieved directly by bundling [the `tzdata` package][tzdata]. Refer to its docs
 for more info.
+
+### `DBS_TO_EXCLUDE`
+
+Define a Regular Expression to filter databases that shouldn't be included in the DB
+dump.
+
+You can use this to avoid getting permission errors when running a backup against a
+server where you don't control all the databases.
+
+For example, if you don't want to include the databases named `DB1` and `DB2` you can
+use:
+
+```bash
+DBS_TO_EXCLUDE="^(DB1|DB2)$"
+```
 
 ## Set a custom hostname!
 


### PR DESCRIPTION
Adds `DBS_TO_EXCLUDE` environment variable to filter `pg_dump` target dbs. 
Allows passing a regex to filter DBs.

Also updated prettier/prettier to prettier/pre-commit (#prettiermageddon)

@Tecnativa
TT26621