### PR TITLE
Fix grep installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,6 +232,9 @@ RUN set -eux; \
 	\
 	postgres --version
 
+# Install full version of grep to support more options
+RUN apk add --no-cache grep
+
 ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
 ENV JOB_200_WHEN='daily weekly' \
     PGHOST=db


### PR DESCRIPTION
Current `grep` version in the image does not allow for complex options, neither does it support the `--null-data` one, which we need to filter the DBs that shouldn't be backed up.

This ensures we have the correct grep version.

TT26621

ping @Yajo 