### PR TITLE
Fix DB excludes expression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ RUN set -eux; \
 # Install full version of grep to support more options
 RUN apk add --no-cache grep
 
-ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
+ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"\$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
 ENV JOB_200_WHEN='daily weekly' \
     PGHOST=db
 


### PR DESCRIPTION
The $ sign was not being escaped from the Dockerfile, so the `grep` was being set at build time with the default value of "$^".

This escapes the sign, same as with $SRC a little ahead in the expression, ensuring the correct value is assumed.

Old behaviour:
```
/ # echo $JOB_200_WHAT
psql -0Atd postgres -c "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres'" | grep --null-data --invert-match -E "$^" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file "$SRC/DB.sql"
```

After this fix:
```
bash-5.0# echo $JOB_200_WHAT 
psql -0Atd postgres -c "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres'" | grep --null-data --invert-match -E "$DBS_TO_EXCLUDE" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file "$SRC/DB.sql"
```

TT26621