### PR TITLE
Fix false positive in psql command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,29 +7,28 @@ repos:
         language: fail
         files: "\\.rej$"
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.1.0
+    rev: v2.7.4
     hooks:
       - id: pyupgrade
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.6.4
     hooks:
       - id: isort
-        additional_dependencies: ["isort[pyproject]"]
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.0
+    rev: v2.2.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -43,7 +42,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/thlorenz/doctoc
-    rev: v1.4.0
+    rev: v2.0.0
     hooks:
       - id: doctoc
         args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ RUN set -eux; \
 # Install full version of grep to support more options
 RUN apk add --no-cache grep
 
-ENV JOB_200_WHAT psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"\$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
+ENV JOB_200_WHAT set -euo pipefail; psql -0Atd postgres -c \"SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != \'postgres\'\" | grep --null-data --invert-match -E \"\$DBS_TO_EXCLUDE\" | xargs -0tI DB pg_dump --dbname DB --no-owner --no-privileges --file \"\$SRC/DB.sql\"
 ENV JOB_200_WHEN='daily weekly' \
     PGHOST=db
 


### PR DESCRIPTION
Because of the command pipelining, the return code of `JOB_200_WHAT` wasn't taking in consideration the result of the first `psql` command.

This ensures the command fails when any command exits with a return code different from 0, and keeps that exit code.

TT27204

**Example**:
Before, when you had a wrong password, for example:
```bash
bash-5.0# psql -0Atd postgres -c "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres'" | grep --null-data --invert-match -E \"\$DBS_TO_EXCLUDE\" | xargs -0tI DB echo DB
psql: error: could not connect to server: FATAL:  password authentication failed for user "myuser"
bash-5.0# echo $?
0
 ```

After this fix:
```bash
bash-5.0# set -euo pipefail; psql -0Atd postgres -c "SELECT datname FROM pg_database WHERE NOT datistemplate AND datname != 'postgres'" | grep --null-data --invert-match -E \"\$DBS_TO_EXCLUDE\" | xargs -0tI DB echo DB
psql: error: could not connect to server: FATAL:  password authentication failed for user "myuser"
```
(bash exits)
In the host system:
```fish
jota@jlap:~/D/T/i/docker-duplicity|fix-false-positive⚡*
➤ echo $status
1
```