### PR TITLE
[IMP] Conditional SMTP reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV CRONTAB_15MIN='*/15 * * * *' \
     SMTP_PORT='25' \
     SMTP_TLS='' \
     SMTP_USER='' \
+    SMTP_REPORT_SUCCESS='1' \
     SRC='/mnt/backup/src'
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ ENV CRONTAB_15MIN='*/15 * * * *' \
     OPTIONS='' \
     OPTIONS_EXTRA='--metadata-sync-mode partial' \
     SMTP_HOST='smtp' \
-    SMTP_PASS='' \
     SMTP_PORT='25' \
-    SMTP_TLS='' \
     SMTP_USER='' \
+    SMTP_PASS='' \
+    SMTP_TLS='' \
     SMTP_REPORT_SUCCESS='1' \
     SRC='/mnt/backup/src'
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [`SMTP_USER`](#smtp_user)
   - [`SMTP_PASS`](#smtp_pass)
   - [`SMTP_TLS`](#smtp_tls)
+  - [`SMTP_REPORT_SUCCESS`](#smtp_report_success)
   - [`SRC`](#src)
   - [`TZ`](#tz)
 - [Set a custom hostname!](#set-a-custom-hostname)
@@ -222,6 +223,11 @@ If your mail server requires authentication, specify the password for the SMTP_U
 
 Force the email client to connect to the server using SLL/TLS. Note that the client will
 utilize STARTTLS, regardless of this variable, if the server offers STARTTLS.
+
+### `SMTP_REPORT_SUCCESS`
+
+If enabled, report via SMTP regardless of exit status (this is the default behaviour).
+Otherwise, only report if one or more jobs failed.
 
 ### `SRC`
 

--- a/bin/jobrunner
+++ b/bin/jobrunner
@@ -29,6 +29,7 @@ smtp_port = environ.get("SMTP_PORT")
 smtp_user = environ.get("SMTP_USER")
 smtp_pass = environ.get("SMTP_PASS", "")
 smtp_tls = environ.get("SMTP_TLS", "").lower() in {"1", "true"}
+smtp_report_success = environ.get("SMTP_REPORT_SUCCESS").lower() in {"1", "true"}
 from_ = environ.get("EMAIL_FROM")
 to = environ.get("EMAIL_TO")
 subject = environ.get("EMAIL_SUBJECT")
@@ -77,7 +78,7 @@ for njob, command in sorted(to_run.items()):
 
 
 # Report results
-if all((smtp_host, smtp_port, from_, to, subject)):
+if all((smtp_report_success or failed, smtp_host, smtp_port, from_, to, subject)):
     logging.info("Sending email report")
     smtp = None
     try:


### PR DESCRIPTION
Add environment variable `SMTP_ALWAYS` to allow limiting SMTP reports to those where jobs failed. Preserve current behaviour by defaulting to `SMTP_ALWAYS=1`.

I took some liberties rearranging the order of `SMTP_*` variables in the Dockerfile to match those in the README, feel free to undo those changes if they were in that order for some reason.