### PR TITLE
[FIX] Update isort version on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,8 @@ repos:
     hooks:
       - id: black
         additional_dependencies: ["click<8.1.0"]
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         args:


### PR DESCRIPTION
To avoid the isort problem (PyCQA/isort#2077)

@Tecnativa