### PR TITLE
[IMP] Postgres images with explicit version

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -9,5 +9,15 @@ $CRONTAB_WEEKLY run-parts /etc/periodic/weekly
 $CRONTAB_MONTHLY run-parts /etc/periodic/monthly
 END
 
+# Install selected postgres-client if needed
+if [ -n "$PGHOST" ]; then
+    ORIG_PWD=$(pwd)
+    cd "$APK_POSTGRES_DIR/$DB_VERSION"
+    apk add *.apk
+    cd $ORIG_PWD
+    # Smoke test
+    psql --version && pg_dump --version
+fi
+
 # Continue work
 exec "$@"


### PR DESCRIPTION
This PR adds support for postgres flavours with explicit version...

NOTE: pg_dump 9.6 is not installable due to the alpine version used. So... doodba-copier-template can't up the backup service when use postgresql 9.6