### PR TITLE
[FIX] Use os.environ instead of os.putenv to set environment variables

### DIFF
--- a/bin/dup
+++ b/bin/dup
@@ -21,7 +21,7 @@ def _set_env(index):
     for target_env_raw_name in target_environ_raw_names:
         env_value = os.getenv(target_env_raw_name)
         target_env_name = re.findall(r"^DST_\d+_(\w+)$", target_env_raw_name)[0]
-        os.putenv(target_env_name, env_value)
+        os.environ[target_env_name] = env_value
 
     # Expand shell commands from environment options
     # this resolves environment variables used in the string


### PR DESCRIPTION
Currently `_set_env` [uses putenv](https://github.com/Tecnativa/docker-duplicity/blob/3565426cb39faa8b904ddf0e5c5d89e72204f4d7/bin/dup#L24) to set destination specific environment variables (`DST_{index}_*`). This does not update the `os.environ` mapping, as stated in the [documentation](https://docs.python.org/3/library/os.html#os.putenv), only calling the underlying [C implementation](https://github.com/python/cpython/blob/main/Modules/clinic/posixmodule.c.h#L8119). This causes all subsequent fetches to `DST_{index}_*` variables to behave as if they write had not occurred, thus rendering them useless.

The fix simply replaces `os.putenv` with `os.environ`. I would also like to modify the tests for multi to cover the usage of these variables, but am not too sure about how to proceed. Perhaps adding `DST_1_OPTIONS=--log-file=dup.log` and checking for the existence of `dup.log` would be enough? 