### PR TITLE
[DCK] Downgrade python version to 3.11 on Dockerfile due to incompatibilities between Python 3.12 and Duplicity 1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM python:3-slim AS builder
+FROM python:3.11-slim AS builder
 
 WORKDIR /app
 ADD pyproject.toml poetry.lock ./
 RUN pip install --no-cache-dir poetry
 
 # Build a requirements.txt file matching poetry.lock, that pip understands
+# Test comment
 RUN poetry export --extras duplicity --output /app/requirements.txt
 
-FROM python:3-alpine AS base
+FROM python:3.11-alpine AS base
 
 ENV CRONTAB_15MIN='*/15 * * * *' \
     CRONTAB_HOURLY='0 * * * *' \

--- a/bin/jobrunner
+++ b/bin/jobrunner
@@ -22,7 +22,6 @@ logging.root.name = "jobrunner"
 # Get expected periodicity from this script's placement
 periodicity = path.basename(path.dirname(path.abspath(__file__)))
 logging.info("%s UTC - Running %s jobs", datetime.utcnow(), periodicity)
-
 # Get email settings
 smtp_host = environ.get("SMTP_HOST")
 smtp_port = environ.get("SMTP_PORT")


### PR DESCRIPTION
@Tecnativa TT45299