### PR TITLE
Add support for pinging healthchecks.io and uptime-kuma

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   - [`EMAIL_TO`](#email_to)
   - [`JOB_*_WHAT`](#job__what)
   - [`JOB_*_WHEN`](#job__when)
+  - [`JOB_*_HEALTHCHECKS_URL`](#job__healthchecks_url)
+  - [`JOB_*_UPTIME_KUMA_URL`](#job__uptime_kuma_url)
   - [`OPTIONS`](#options)
   - [`OPTIONS_EXTRA`](#options_extra)
   - [`SMTP_HOST`](#smtp_host)
@@ -193,6 +195,24 @@ several values, you can separate them with spaces (example: `daily monthly`).
 
 [Prebuilt flavors][flavors] provide built-in jobs. You can disable those jobs by setting
 corresponding `JOB_*_WHEN` to value `never`.
+
+### `JOB_*_HEALTHCHECKS_URL`
+
+[healthchecks](https://healthchecks.io/) URL to ping on job success or failure. Supports
+"start", "success", and "failure" pings. For a job that runs with multiple
+periodicities, the periodicity can be added to the env var (e.g.
+`JOB_200_DAILY_HEALTHCHECKS_URL` or `JOB_200_WEEKLY_HEALTHCHECKS_URL`) to specify
+different URLs for each run. Periodicity-specific env vars take precedence over the
+general one.
+
+### `JOB_*_UPTIME_KUMA_URL`
+
+[uptime-kuma](https://github.com/louislam/uptime-kuma) push monitor URL to ping on job
+success or failure. Supports "up" and "down" pings. Do not include any query parameters
+in the URL. For a job that runs with multiple periodicities, the periodicity can be
+added to the env var (e.g. `JOB_200_DAILY_UPTIME_KUMA_URL` or
+`JOB_200_WEEKLY_UPTIME_KUMA_URL`) to specify different URLs for each run.
+Periodicity-specific env vars take precedence over the general one.
 
 ### `OPTIONS`
 

--- a/bin/jobrunner
+++ b/bin/jobrunner
@@ -14,6 +14,9 @@ from os import environ, path
 from socket import getfqdn
 from string import Template
 from subprocess import STDOUT, CalledProcessError, check_output
+from uuid import uuid4
+
+import requests
 
 logging.basicConfig(level=logging.INFO)
 logging.root.name = "jobrunner"
@@ -32,6 +35,7 @@ smtp_report_success = environ.get("SMTP_REPORT_SUCCESS").lower() in {"1", "true"
 from_ = environ.get("EMAIL_FROM")
 to = environ.get("EMAIL_TO")
 subject = environ.get("EMAIL_SUBJECT")
+healthchecks_request_timeout = 5
 
 # Get the commands we need to run
 to_run = {}
@@ -53,6 +57,26 @@ for njob, command in sorted(to_run.items()):
     expanded_command = Template(command).safe_substitute(environ)
     start = datetime.now()
     logging.info("Running job %d: `%s`", njob, expanded_command)
+    healthchecks_url_env = environ.get(
+        f"JOB_{njob}_{periodicity.upper()}_HEALTHCHECKS_URL"
+    ) or environ.get(f"JOB_{njob}_HEALTHCHECKS_URL")
+    if healthchecks_url_env is not None:
+        healthchecks_rid = str(uuid4())
+        message += [f"Pinging {healthchecks_url_env}/start"]
+        logging.info(message[-1])
+        try:
+            requests.get(
+                f"{healthchecks_url_env}/start",
+                params={"rid": healthchecks_rid},
+                timeout=healthchecks_request_timeout,
+            )
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ):
+            message += ["Failed to send healtchecks start request"]
+            logging.exception(message[-1])
+
     try:
         result = check_output(expanded_command, stderr=STDOUT, shell=True, text=True)
         success = True
@@ -75,6 +99,53 @@ for njob, command in sorted(to_run.items()):
     logging.log(logging.INFO if success else logging.ERROR, "\n".join(log))
     message += log
 
+    if healthchecks_url_env is not None:
+        request_url = (
+            f"{healthchecks_url_env}/fail" if failed else f"{healthchecks_url_env}"
+        )
+        message += [f"Pinging {request_url}"]
+        logging.info(message[-1])
+        try:
+            requests.get(
+                request_url,
+                params={"rid": healthchecks_rid},
+                timeout=healthchecks_request_timeout,
+            )
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ):
+            message += ["Failed to send healthchecks finished request"]
+            logging.exception(message[-1])
+
+    uptime_kuma_url_env = environ.get(
+        f"JOB_{njob}_{periodicity.upper()}_UPTIME_KUMA_URL"
+    ) or environ.get(f"JOB_{njob}_UPTIME_KUMA_URL")
+    if uptime_kuma_url_env is not None:
+        # Remove any query params in the URL, since the uptime-kuma interface includes them by default
+        if "?" in uptime_kuma_url_env:
+            uptime_kuma_url_env = uptime_kuma_url_env[: uptime_kuma_url_env.find("?")]
+
+        if failed:
+            status = "down"
+            msg = result
+        else:
+            status = "up"
+            msg = "ok"
+        try:
+            message += [f"Pinging {uptime_kuma_url_env}"]
+            logging.info(message[-1])
+            requests.get(
+                f"{uptime_kuma_url_env}",
+                params={"status": status, "msg": msg},
+                timeout=healthchecks_request_timeout,
+            )
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+        ):
+            message += ["Failed to send uptime kuma ping request"]
+            logging.exception(message[-1])
 
 # Report results
 if all((smtp_report_success or failed, smtp_host, smtp_port, from_, to, subject)):

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,7 +207,7 @@ files = [
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
@@ -305,7 +305,7 @@ files = [
 name = "charset-normalizer"
 version = "3.0.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "charset-normalizer-3.0.1.tar.gz", hash = "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f"},
@@ -742,7 +742,7 @@ tests = ["freezegun", "pytest", "pytest-cov"]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -1735,7 +1735,7 @@ files = [
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
@@ -1938,7 +1938,7 @@ files = [
 name = "urllib3"
 version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
@@ -2039,4 +2039,4 @@ duplicity = ["PyDrive", "PyDrive2", "b2", "b2sdk", "boto", "boto3", "dropbox", "
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5abfd056f34ac3c7dec3f01794f6dc5c88dfdb9e154b8d1ef9e6443be202e40d"
+content-hash = "c262ad5776c5d84fbd7b0fc7e52173d2f27502b28f4a56acc0ea062b86b07019"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ python-keystoneclient = {version = "^5.2.0", optional = true}
 idna = {version = "3.4", optional = true}
 pyyaml = "6.0.1"
 lxml = "4.9.3"
+requests = "^2.31.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.3"


### PR DESCRIPTION
Added dependency: `requests` since the python version used doesn't support request timeouts in the standard library.

I catch network related exceptions so other jobs run even on ping failure, assuming that the healthcheck would notify users if that happens.

Tested with docker compose:

```yml
services:
  db:
    image: postgres:15.4-alpine
    environment:
      POSTGRES_PASSWORD: mypass
      POSTGRES_USER: myuser
      POSTGRES_DB: somedb
    networks:
      - test
  backup:
    image: duplicity
    hostname: my.postgres.backup
    volumes:
      - ./src:/mnt/backup/src
      - ./dst:/mnt/backup/dst
      - ./bin/jobrunner:/etc/periodic/15min/jobrunner
    environment:
      # Postgres connection
      PGHOST: db # This is the default
      PGPASSWORD: mypass
      PGUSER: myuser

      # Additional configurations for Duplicity
      DST: file:///mnt/backup/dst
      PASSPHRASE: example backkup encryption secret
      JOB_200_WHEN: 15min daily weekly
      JOB_300_WHEN: 15min daily weekly
      CRONTAB_15MIN: "44,47,50,53,56,59 * * * *"
      CRONTAB_DAILY: "45,48,51,54,57,0 * * * *"
      CRONTAB_WEEKLY: "46,49,52,55,58,1 * * * *"
      JOB_200_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/2bffaed5-278f-465a-a565-bf301c7410eb
      JOB_200_15MIN_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/699634a1-5cd0-449e-a982-f762d3fc2a5d
      JOB_200_DAILY_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/5cb0d102-eda7-4b89-8511-59bbe5c668e4
      JOB_300_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/9f853cc4-4a57-4eb2-97cf-37dd847a8827
      JOB_300_15MIN_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/27f40fa8-20ca-45bb-acfd-61f9c4fba4c6
      JOB_300_DAILY_HEALTHCHECKS_URL: https://healthchecks.domain.tld/ping/0043f21d-b393-44c4-8a86-2d3396b0a761
      JOB_200_UPTIME_KUMA_URL: https://status.domain.tld/api/push/XVcfKlQyFi?status=up&msg=OK&ping=
      JOB_200_15MIN_UPTIME_KUMA_URL: https://status.domain.tld/api/push/2UMvNBvz2U?status=up&msg=OK&ping=
      JOB_200_DAILY_UPTIME_KUMA_URL: https://status.domain.tld/api/push/hbT1YBaF5l?status=up&msg=OK&ping=
      JOB_300_UPTIME_KUMA_URL: https://status.domain.tld/api/push/nNxWnrRca1?status=up&msg=OK&ping=
      JOB_300_15MIN_UPTIME_KUMA_URL: https://status.domain.tld/api/push/wbUqPjrniB?status=up&msg=OK&ping=
      JOB_300_DAILY_UPTIME_KUMA_URL: https://status.domain.tld/api/push/XET8tjLJOP?status=up&msg=OK&ping=
    networks:
      - test

networks:
  test:
```