### PR TITLE
[FIX] Changed the PostgreSQL 12 repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
     apk fetch --no-cache --repositories-file psql_repos postgresql-client -o "$APK_POSTGRES_DIR/10"; \
     echo "http://dl-cdn.alpinelinux.org/alpine/v3.10/main" > psql_repos; \
     apk fetch --no-cache --repositories-file psql_repos postgresql-client -o "$APK_POSTGRES_DIR/11"; \
-    echo "http://dl-cdn.alpinelinux.org/alpine/v3.14/main" > psql_repos; \
+    echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" > psql_repos; \
     apk fetch --no-cache --repositories-file psql_repos postgresql-client -o "$APK_POSTGRES_DIR/12"; \
     apk fetch --no-cache postgresql13-client -o "$APK_POSTGRES_DIR/13"; \
     apk fetch --no-cache postgresql14-client -o "$APK_POSTGRES_DIR/14"; \


### PR DESCRIPTION
CC @Tecnativa TT48361
The previous one referenced version 13 of PostgreSQL, as seen in the Alpine documentation: https://alpinelinux.org/posts/Alpine-3.14.0-released.html. To fix this issue, the latest Alpine release with PostgreSQL 12 was sought, which is version 3.12. This was also confirmed in the documentation: https://alpinelinux.org/posts/Alpine-3.12.0-released.html

This will fix test assertion error (https://github.com/Tecnativa/doodba-copier-template/actions/runs/8139020573/job/22241212135#step:14:122) on https://github.com/Tecnativa/doodba-copier-template