### PR TITLE
[IMP] Dockerfile: create known_hosts file

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -19,5 +19,10 @@ if [ -n "$PGHOST" ]; then
     psql --version && pg_dump --version
 fi
 
+# Create needed .ssh files
+mkdir -p /root/.ssh && touch /root/.ssh/known_hosts
+chmod 700 /root/.ssh
+chmod 644 /root/.ssh/known_hosts
+
 # Continue work
 exec "$@"


### PR DESCRIPTION
When a ssh/sftp connection is configured, the first run (both backup or jobrunner) fails because there is no file `/root/.ssh/known_hosts`, which has to be created manually.
This fix in `Dockerfile` creates `.ssh` folder and `known_hosts` file, in order to make the first run right and avoid this kind of error.