### PR TITLE
fix(backup): add action to binary

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x
-exec dup "$SRC" "$DST" "$@"
+exec dup backup "$SRC" "$DST" "$@"


### PR DESCRIPTION
At some point, recent duplicity started yelling this error when running `backup`:

    CommandLineError: Invalid 'file:///mnt/backup/src' action and cannot be implied from the given arguments:

Some time ago, the `backup` action was implicit, but it must be explicit now.

@moduon MT-13412